### PR TITLE
refactor: move to newer avro, compat checker, fix shadow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import org.hypertrace.gradle.publishing.License.APACHE_2_0
+
 plugins {
   `java-gradle-plugin`
   id("org.hypertrace.ci-utils-plugin") version "0.3.0"
@@ -28,11 +28,6 @@ hypertracePublish {
   license.set(APACHE_2_0)
 }
 
-repositories {
-  maven("http://packages.confluent.io/maven")
-  jcenter()
-
-}
 
 val bundled by configurations.creating {
   setTransitive(false);
@@ -44,9 +39,9 @@ configurations.implementation {
 
 dependencies {
   shadow(gradleApi())
-  shadow("com.commercehub.gradle.plugin:gradle-avro-plugin:0.19.1")
+  shadow("com.github.davidmc24.gradle.plugin:gradle-avro-plugin:1.1.0")
   // avro - compiler, tools
-  shadow("org.apache.avro:avro-compiler:1.9.2")
+  shadow("org.apache.avro:avro-compiler:1.10.2")
   // for compatibility checker library
   bundled("io.confluent:kafka-schema-registry-client:6.1.1")
 }
@@ -55,16 +50,11 @@ tasks.jar {
   enabled = false;
 }
 
-val relocationTask = tasks.register<ConfigureShadowRelocation>("relocatePackages") {
-  target = tasks.shadowJar.get()
-  prefix = "org.hypertrace.shaded"
-}
-
 tasks.shadowJar {
-  dependsOn(relocationTask)
   minimize()
   archiveClassifier.set("")
   configurations = listOf(bundled)
+  relocate("io.confluent.kafka", "org.hypertrace.shaded.io.confluent.kafka")
 }
 tasks.assemble {
   dependsOn(tasks.shadowJar)

--- a/src/main/java/org/hypertrace/gradle/avro/AvroPlugin.java
+++ b/src/main/java/org/hypertrace/gradle/avro/AvroPlugin.java
@@ -22,7 +22,7 @@ public class AvroPlugin implements Plugin<Project> {
   @Override
   public void apply(@Nonnull Project project) {
     project.getPlugins().apply(BasePlugin.class);
-    project.getPlugins().apply(com.commercehub.gradle.plugin.avro.AvroPlugin.class);
+    project.getPlugins().apply(com.github.davidmc24.gradle.plugin.avro.AvroPlugin.class);
     AvroPluginExtension extension =
         project.getExtensions().create(EXTENSION_NAME, AvroPluginExtension.class, project);
 


### PR DESCRIPTION
## Description

This fixes the packaging of the previous shadow plugin by only shadowing one specific jar (confluent stuck something outside their group into the 6.1.1 version of their jar, causing avro to be shadowed). As part of that, also upgraded several dependencies including the bundled avro plugin (which itself moved off bintray and renamed) and avro.

Migrated the compatibility check itself to use the schema registry's newer, non-deprecated variant which required a bit of type changing.

### Testing
Manually verified against an avro project both for success and error conditions.
